### PR TITLE
Fix: Create /root/.gnupg directory before rpm import/install

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -2,6 +2,9 @@
 
 set -ouex pipefail
 
+mkdir -p /root/.gnupg
+chmod 700 /root/.gnupg
+
 # Install RPM Fusion free and nonfree repositories
 dnf5 install -y \
   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \


### PR DESCRIPTION
The build was failing with a gpg error indicating it couldn't create the /root/.gnupg directory. This commit adds commands to explicitly create this directory with appropriate permissions (0700) at the beginning of the build script to ensure gpg can function correctly during package installation and key import.