### PR TITLE
Fix: Correctly create /root/.gnupg directory

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -2,7 +2,7 @@
 
 set -ouex pipefail
 
-mkdir -p /root/.gnupg
+mkdir /root/.gnupg
 chmod 700 /root/.gnupg
 
 # Install RPM Fusion free and nonfree repositories


### PR DESCRIPTION
The previous attempt to create /root/.gnupg failed because /root already exists and the busybox version of mkdir -p errors in this case. This commit changes the command to `mkdir /root/.gnupg` to specifically create only the .gnupg directory.