### PR TITLE
Fix: Create /root/.gnupg directory immediately before use

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -2,9 +2,6 @@
 
 set -ouex pipefail
 
-mkdir /root/.gnupg
-chmod 700 /root/.gnupg
-
 # Install RPM Fusion free and nonfree repositories
 dnf5 install -y \
   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
@@ -32,6 +29,8 @@ dnf5 install -y \
   sysprof tiptop zsh ublue-setup-services
 
 # Install VSCode
+mkdir -p /root/.gnupg
+chmod 700 /root/.gnupg
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/vscode.repo'
 dnf5 install -y code


### PR DESCRIPTION
I've moved the `mkdir -p /root/.gnupg` and `chmod 700 /root/.gnupg` commands to immediately before the `rpm --import` and subsequent `dnf5 install` commands that require gpg. This aims to ensure the directory exists with the correct permissions at the exact moment it's needed, hopefully resolving previous build failures related to gpg directory creation.