### PR TITLE
Fix(build): Correct GPG directory creation for /root symlink

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -2,6 +2,22 @@
 
 set -ouex pipefail
 export HOME=/root
+echo "--- GPG SETUP START ---"
+echo "Ensuring GPG directory exists at $HOME/.gnupg (which is $(readlink -f "$HOME")/.gnupg )"
+mkdir -vp "$HOME/.gnupg"
+if [ ! -d "$HOME/.gnupg" ]; then
+  echo "ERROR: $HOME/.gnupg was NOT created."
+  echo "Attempting to list $HOME and its target (if symlink):"
+  ls -ld "$HOME" || echo "$HOME not found or not listable"
+  if [ -L "$HOME" ]; then
+    ls -ld "$(readlink -f "$HOME")" || echo "Target of $HOME symlink not found or not listable"
+    ls -ld "$(readlink -f "$HOME")/.gnupg" || echo "Target $HOME/.gnupg not found or not listable after mkdir attempt"
+  fi
+  exit 1
+fi
+chmod 700 "$HOME/.gnupg"
+echo "GPG directory $HOME/.gnupg ensured and permissions set."
+echo "--- GPG SETUP END ---"
 
 # Install RPM Fusion free and nonfree repositories
 dnf5 install -y \
@@ -39,14 +55,6 @@ ls -ld /root || echo "/root does not exist or cannot be listed."
 echo "Filesystem disk space usage:"
 df -h
 echo "--- DIAGNOSTICS END ---"
-mkdir -v -p /root/.gnupg
-if [ -d "/root/.gnupg" ]; then
-  echo "/root/.gnupg successfully created."
-else
-  echo "ERROR: /root/.gnupg was NOT created."
-  exit 1
-fi
-chmod 700 /root/.gnupg
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/vscode.repo'
 dnf5 install -y code


### PR DESCRIPTION
The build script was failing because /root is a symlink to /var/roothome in the fedora-bootc image. Operations like 'mkdir -p /root/.gnupg' would fail as '/root' itself was seen as a file (the symlink). Additionally, GPG operations within dnf5 were failing because $HOME/.gnupg (resolving to /root/.gnupg) could not be created.

This commit addresses the issue by:
1. Ensuring `export HOME=/root` is set at the beginning of build_files/build.sh.
2. Moving the creation of the GPG directory (`$HOME/.gnupg`) to the top of the script, before any dnf5 or rpm commands that might invoke GPG. Using "$HOME/.gnupg" ensures that the path correctly resolves through the /root symlink to /var/roothome/.gnupg.
3. Removing the previous, problematic mkdir attempts for /root/.gnupg from the VSCode installation section.

Diagnostic commands remain in place to monitor the build environment.