### PR TITLE
I'm going to refactor the build script for ISO creation. Here's what …

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -54,6 +54,7 @@ dnf5 install -y \
   qt5ct qt6ct \
   sddm sddm-wayland-generic
 
+<<<<<<< ours
 # Install Bazzite-DX applications
 dnf5 install -y \
   gamescope-session-plus gamescope-session-steam \
@@ -74,6 +75,82 @@ echo "--- DIAGNOSTICS END ---"
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/vscode.repo'
 dnf5 install -y code
+=======
+# Install Bazzite-DX applications (bcc, bpftrace, bpftop removed)
+dnf5 install -y \
+  gamescope-session-plus gamescope-session-steam \
+  android-tools flatpak-builder ccache nicstat numactl \
+  podman-machine podman-tui python3-ramalama qemu-kvm restic rclone \
+  sysprof tiptop zsh ublue-setup-services
+
+# Install Cursor AppImage
+echo "--- Installing Cursor ---"
+CURSOR_APPIMAGE_URL="https://download.cursor.sh/linux/latest/Cursor.AppImage" # !!! USER: VERIFY THIS URL !!!
+CURSOR_INSTALL_DIR="/opt/Cursor"
+CURSOR_APPIMAGE_NAME="Cursor.AppImage"
+CURSOR_DESKTOP_FILE="/usr/share/applications/cursor.desktop"
+
+mkdir -p "$CURSOR_INSTALL_DIR"
+if command -v curl >/dev/null 2>&1; then
+  curl -L "$CURSOR_APPIMAGE_URL" -o "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
+elif command -v wget >/dev/null 2>&1; then
+  wget "$CURSOR_APPIMAGE_URL" -O "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
+else
+  echo "ERROR: Neither curl nor wget is available to download Cursor. Please install one of them."
+  # If this is critical, you might want to exit: exit 1
+fi
+
+if [ -f "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME" ]; then
+  chmod +x "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
+  echo "Cursor downloaded and made executable at $CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
+
+  # Create .desktop file for Cursor
+  echo "Creating .desktop file for Cursor..."
+  cat > "$CURSOR_DESKTOP_FILE" <<EOF_DESKTOP
+[Desktop Entry]
+Name=Cursor
+Comment=AI First Code Editor
+Exec=$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME --no-sandbox %U
+Icon=cursor # Placeholder: User may need to download an icon and set the full path
+Type=Application
+Categories=Development;IDE;TextEditor;
+StartupWMClass=Cursor
+MimeType=text/plain;inode/directory;
+EOF_DESKTOP
+  echo ".desktop file created at $CURSOR_DESKTOP_FILE"
+else
+  echo "ERROR: Cursor AppImage download failed from $CURSOR_APPIMAGE_URL. Please check the URL."
+  # Consider exiting with an error if Cursor is essential: exit 1
+fi
+echo "--- Cursor Installation Attempted ---"
+
+# Install Warp Terminal
+echo "--- Installing Warp Terminal ---"
+WARP_RPM_URL="https://app.warp.dev/get_warp?package=rpm"
+WARP_RPM_LOCAL_PATH="/tmp/warp-terminal-latest.rpm" # Save with a generic name
+
+if command -v curl >/dev/null 2>&1; then
+  curl -L "$WARP_RPM_URL" -o "$WARP_RPM_LOCAL_PATH"
+elif command -v wget >/dev/null 2>&1; then
+  # wget by default uses the server-provided name, so -O is needed for a fixed local name
+  wget "$WARP_RPM_URL" -O "$WARP_RPM_LOCAL_PATH"
+else
+  echo "ERROR: Neither curl nor wget is available to download Warp Terminal. Please install one of them."
+  # Consider exiting if Warp is essential: exit 1
+fi
+
+if [ -f "$WARP_RPM_LOCAL_PATH" ]; then
+  echo "Warp Terminal RPM downloaded to $WARP_RPM_LOCAL_PATH"
+  dnf5 install -y "$WARP_RPM_LOCAL_PATH"
+  rm -f "$WARP_RPM_LOCAL_PATH" # Clean up the downloaded RPM
+  echo "Warp Terminal installed and RPM cleaned up."
+  # RPMs usually install their own .desktop files.
+else
+  echo "ERROR: Warp Terminal RPM download failed from $WARP_RPM_URL. Please check the URL."
+  # Consider exiting if Warp is essential: exit 1
+fi
+echo "--- Warp Terminal Installation Attempted ---"
+>>>>>>> theirs
 
 # Install Docker CE
 sh -c 'echo -e "[docker-ce-stable]\nname=Docker CE Stable - \$basearch\nbaseurl=https://download.docker.com/linux/fedora/\$releasever/\$basearch/stable\nenabled=1\ngpgcheck=1\ngpgkey=https://download.docker.com/linux/fedora/gpg" > /etc/yum.repos.d/docker-ce.repo'
@@ -87,18 +164,33 @@ dnf5 remove -y gnome-shell plasma-desktop kde-plasma-desktop xfce4-session mate-
 
 # Enable essential services
 systemctl enable sddm
+<<<<<<< ours
 # User services will be enabled via ublue-os/startingpoint or similar mechanism for user session
 # e.g. systemctl --user enable pipewire pipewire-pulse wireplumber
 
 # Create a basic Hyprland desktop entry for SDDM
 mkdir -p /usr/share/wayland-sessions
 cat > /usr/share/wayland-sessions/hyprland.desktop <<EOF
+=======
+
+# Create a basic Hyprland desktop entry for SDDM
+mkdir -p /usr/share/wayland-sessions
+cat > /usr/share/wayland-sessions/hyprland.desktop <<EOF_HYPRLAND
+>>>>>>> theirs
 [Desktop Entry]
 Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
 Exec=Hyprland
 Type=Application
+<<<<<<< ours
 EOF
 
 # Clean up
 dnf5 clean all
+=======
+EOF_HYPRLAND
+
+# Clean up
+dnf5 clean all
+EOF
+>>>>>>> theirs

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -88,7 +88,7 @@ echo "--- Installing Cursor ---"
 CURSOR_APPIMAGE_URL="https://download.cursor.sh/linux/latest/Cursor.AppImage" # !!! USER: VERIFY THIS URL !!!
 CURSOR_INSTALL_DIR="/opt/Cursor"
 CURSOR_APPIMAGE_NAME="Cursor.AppImage"
-CURSOR_DESKTOP_FILE="/usr/share/applications/cursor.desktop"
+CURSOR_DESKTOP_FILE_PATH="/usr/share/applications/cursor.desktop"
 
 mkdir -p "$CURSOR_INSTALL_DIR"
 if command -v curl >/dev/null 2>&1; then
@@ -104,20 +104,18 @@ if [ -f "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME" ]; then
   chmod +x "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
   echo "Cursor downloaded and made executable at $CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME"
 
-  # Create .desktop file for Cursor
+  # Create .desktop file for Cursor using echo commands
   echo "Creating .desktop file for Cursor..."
-  cat > "$CURSOR_DESKTOP_FILE" <<'EOF_DESKTOP'
-[Desktop Entry]
-Name=Cursor
-Comment=AI First Code Editor
-Exec=/opt/Cursor/Cursor.AppImage --no-sandbox %U
-Icon=cursor # Placeholder: User may need to download an icon and set the full path
-Type=Application
-Categories=Development;IDE;TextEditor;
-StartupWMClass=Cursor
-MimeType=text/plain;inode/directory;
-EOF_DESKTOP
-  echo ".desktop file created at $CURSOR_DESKTOP_FILE"
+  echo "[Desktop Entry]" > "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Name=Cursor" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Comment=AI First Code Editor" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Exec=$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME --no-sandbox %U" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Icon=cursor # Placeholder: User may need to download an icon and set the full path" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Type=Application" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "Categories=Development;IDE;TextEditor;" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "StartupWMClass=Cursor" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo "MimeType=text/plain;inode/directory;" >> "$CURSOR_DESKTOP_FILE_PATH"
+  echo ".desktop file created at $CURSOR_DESKTOP_FILE_PATH"
 else
   echo "ERROR: Cursor AppImage download failed from $CURSOR_APPIMAGE_URL. Please check the URL."
   # Consider exiting with an error if Cursor is essential: exit 1
@@ -127,27 +125,23 @@ echo "--- Cursor Installation Attempted ---"
 # Install Warp Terminal
 echo "--- Installing Warp Terminal ---"
 WARP_RPM_URL="https://app.warp.dev/get_warp?package=rpm"
-WARP_RPM_LOCAL_PATH="/tmp/warp-terminal-latest.rpm" # Save with a generic name
+WARP_RPM_LOCAL_PATH="/tmp/warp-terminal-latest.rpm"
 
 if command -v curl >/dev/null 2>&1; then
   curl -L "$WARP_RPM_URL" -o "$WARP_RPM_LOCAL_PATH"
 elif command -v wget >/dev/null 2>&1; then
-  # wget by default uses the server-provided name, so -O is needed for a fixed local name
   wget "$WARP_RPM_URL" -O "$WARP_RPM_LOCAL_PATH"
 else
   echo "ERROR: Neither curl nor wget is available to download Warp Terminal. Please install one of them."
-  # Consider exiting if Warp is essential: exit 1
 fi
 
 if [ -f "$WARP_RPM_LOCAL_PATH" ]; then
   echo "Warp Terminal RPM downloaded to $WARP_RPM_LOCAL_PATH"
   dnf5 install -y "$WARP_RPM_LOCAL_PATH"
-  rm -f "$WARP_RPM_LOCAL_PATH" # Clean up the downloaded RPM
+  rm -f "$WARP_RPM_LOCAL_PATH"
   echo "Warp Terminal installed and RPM cleaned up."
-  # RPMs usually install their own .desktop files.
 else
-  echo "ERROR: Warp Terminal RPM download failed from $WARP_RPM_URL. Please check the URL."
-  # Consider exiting if Warp is essential: exit 1
+  echo "ERROR: Warp Terminal RPM download failed from $WARP_RPM_URL."
 fi
 echo "--- Warp Terminal Installation Attempted ---"
 >>>>>>> theirs
@@ -171,24 +165,27 @@ systemctl enable sddm
 # Create a basic Hyprland desktop entry for SDDM
 mkdir -p /usr/share/wayland-sessions
 cat > /usr/share/wayland-sessions/hyprland.desktop <<EOF
-=======
-
-# Create a basic Hyprland desktop entry for SDDM
-mkdir -p /usr/share/wayland-sessions
-cat > /usr/share/wayland-sessions/hyprland.desktop <<'EOF_HYPRLAND'
->>>>>>> theirs
 [Desktop Entry]
 Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
 Exec=Hyprland
 Type=Application
-<<<<<<< ours
 EOF
 
 # Clean up
 dnf5 clean all
 =======
-EOF_HYPRLAND
+
+# Create a basic Hyprland desktop entry for SDDM
+echo "Creating .desktop file for Hyprland..."
+HYPRLAND_DESKTOP_FILE_PATH="/usr/share/wayland-sessions/hyprland.desktop"
+mkdir -p "$(dirname "$HYPRLAND_DESKTOP_FILE_PATH")"
+echo "[Desktop Entry]" > "$HYPRLAND_DESKTOP_FILE_PATH"
+echo "Name=Hyprland" >> "$HYPRLAND_DESKTOP_FILE_PATH"
+echo "Comment=An intelligent dynamic tiling Wayland compositor" >> "$HYPRLAND_DESKTOP_FILE_PATH"
+echo "Exec=Hyprland" >> "$HYPRLAND_DESKTOP_FILE_PATH"
+echo "Type=Application" >> "$HYPRLAND_DESKTOP_FILE_PATH"
+echo ".desktop file created at $HYPRLAND_DESKTOP_FILE_PATH"
 
 # Clean up
 dnf5 clean all

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -106,11 +106,11 @@ if [ -f "$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME" ]; then
 
   # Create .desktop file for Cursor
   echo "Creating .desktop file for Cursor..."
-  cat > "$CURSOR_DESKTOP_FILE" <<EOF_DESKTOP
+  cat > "$CURSOR_DESKTOP_FILE" <<'EOF_DESKTOP'
 [Desktop Entry]
 Name=Cursor
 Comment=AI First Code Editor
-Exec=$CURSOR_INSTALL_DIR/$CURSOR_APPIMAGE_NAME --no-sandbox %U
+Exec=/opt/Cursor/Cursor.AppImage --no-sandbox %U
 Icon=cursor # Placeholder: User may need to download an icon and set the full path
 Type=Application
 Categories=Development;IDE;TextEditor;
@@ -175,7 +175,7 @@ cat > /usr/share/wayland-sessions/hyprland.desktop <<EOF
 
 # Create a basic Hyprland desktop entry for SDDM
 mkdir -p /usr/share/wayland-sessions
-cat > /usr/share/wayland-sessions/hyprland.desktop <<EOF_HYPRLAND
+cat > /usr/share/wayland-sessions/hyprland.desktop <<'EOF_HYPRLAND'
 >>>>>>> theirs
 [Desktop Entry]
 Name=Hyprland

--- a/large_files.txt
+++ b/large_files.txt
@@ -1,0 +1,17 @@
+Size (bytes) | SHA-1 | Type | Filename(s)
+----------------------------------------------------------
+11357 | 261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64 | blob | LICENSE
+11324 | aa6cb332f4486f6deb530619f79d3ed9581e35f2 | blob | Justfile
+8855 | 7304a11c5e16099149af31210f433fd9989980b1 | blob | .github/workflows/build.yml
+4364 | 6b98e7fe67e2b68d2a9c59ce10c61adf09cdb949 | blob | build_files/build.sh
+3999 | f4e0432d80f460c44086c30ef97c9be41e161853 | blob | .github/workflows/build-disk.yml
+1192 | 26d89ac0d1e9d405fdae8e14c4aa92b9046f6ef9 | blob | Containerfile
+558 | 69507a210f7a675561bec8ef1d76967a89f637dd | blob | disk_config/iso.toml
+330 | 0b25d4384bd3bd046e70a378954efe1bf02a07dd | commit | N/A (not a blob)
+298 | a681d76d6577a114f5d565e41f34313cd556daf8 | tree | N/A (not a blob)
+178 | de761298be679084ebb5628bdf9184669992f5b0 | blob | cosign.pub
+79 | d74ca97e04eb086489039f6d3eba28b8161aede3 | tree | N/A (not a blob)
+36 | 107309679088ba3c1769d22c677f0c0cb1594834 | tree | N/A (not a blob)
+36 | 86964694d0dee20787fb9e36c4d99b5b4774597a | tree | N/A (not a blob)
+36 | 9a323431b9b17596a4758c559ce791c4d3e55e80 | tree | N/A (not a blob)
+33 | ce35e444cf0aa8e255067021b6789b5a8c93432a | blob | .gitignore


### PR DESCRIPTION
…I'll do:

- Remove the VSCode (code) installation.
- Add an installation for the Cursor AppImage.
- Remove bcc, bpftrace, and bpftop to reduce LLVM/Clang dependencies and save space.
- Add an installation for Warp Terminal via a direct RPM download.

These changes should help resolve "no space left on device" errors during GitHub Actions builds by reducing the overall image size. I'm also updating the editor and terminal choices based on your request. Could you please verify the Cursor AppImage download URL?