### PR TITLE
Fix: Remove stray EOF from build script

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -114,4 +114,3 @@ echo ".desktop file created at $HYPRLAND_DESKTOP_FILE_PATH"
 
 # Clean up
 dnf5 clean all
-EOF


### PR DESCRIPTION
This commit removes an erroneous `EOF` line from the end of the `build_files/build.sh` script. This stray `EOF` was causing the script to fail with a "command not found" error during the container build process (buildah exit status 127).

Removing this line should allow the script to execute correctly.