### PR TITLE
Fix: Correct syntax error in iso.toml

### DIFF
--- a/disk_config/iso.toml
+++ b/disk_config/iso.toml
@@ -7,7 +7,7 @@ bootc switch --mutate-in-place --transport registry ghcr.io/dwpeters88/hypr-blue
 
 [customizations.installer.modules]
 enable = [
-  "org.fedoraproject.Anaconda.Modules.Storage"
+  "org.fedoraproject.Anaconda.Modules.Storage",
   "org.fedoraproject.Anaconda.Modules.Network",
   "org.fedoraproject.Anaconda.Modules.Security",
   "org.fedoraproject.Anaconda.Modules.Services",


### PR DESCRIPTION
A comma was missing in the 'customizations.installer.modules.enable' array in the disk_config/iso.toml file. This prevented the TOML parser from correctly decoding the file, leading to a build failure in the GitHub Actions workflow.

This commit adds the missing comma to resolve the parsing error.