### PR TITLE
Fix: Correct TOML syntax in iso.toml

### DIFF
--- a/disk_config/iso.toml
+++ b/disk_config/iso.toml
@@ -7,7 +7,7 @@ bootc switch --mutate-in-place --transport registry ghcr.io/dwpeters88/hypr-blue
 
 [customizations.installer.modules]
 enable = [
-  "org.fedoraproject.Anaconda.Modules.Storage"
+  "org.fedoraproject.Anaconda.Modules.Storage",
   "org.fedoraproject.Anaconda.Modules.Network",
   "org.fedoraproject.Anaconda.Modules.Security",
   "org.fedoraproject.Anaconda.Modules.Services",


### PR DESCRIPTION
The `customizations.installer.modules.enable` array was missing a comma after the "org.fedoraproject.Anaconda.Modules.Storage" entry. This caused the bootc-image-builder-action to fail with a TOML decoding error.

This commit adds the missing comma to resolve the syntax issue.