### PR TITLE
Fix trailing prompt in build script

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -29,4 +29,4 @@ systemctl enable bluetooth.service || true
 # Clean up
 rm -rf /tmp/*
 
-echo "Build script completed successfully" 
+echo "Build script completed successfully"


### PR DESCRIPTION
## Summary
- ensure build_files/build.sh ends with a newline
- remove trailing prompt text from final echo

## Testing
- `od -An -t x1 -v build_files/build.sh | tail -n 3`

------
https://chatgpt.com/codex/tasks/task_e_684c9540217c83249b832af3125b71f7