### PR TITLE
Fix format recipe message

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -313,7 +313,7 @@ format:
     set -eoux pipefail
     # Check if shfmt is installed
     if ! command -v shfmt &> /dev/null; then
-        echo "shellcheck could not be found. Please install it."
+        echo "shfmt could not be found. Please install it."
         exit 1
     fi
     # Run shfmt on all Bash scripts


### PR DESCRIPTION
## Summary
- fix echo message in the `format` recipe to reference `shfmt`

## Testing
- `just --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c953a2ab083248547388eb3368375