### PR TITLE
Add build context stage to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,6 @@
+FROM scratch AS ctx
+COPY build_files/ /
+
 ARG FEDORA_MAJOR_VERSION=42
 
 FROM quay.io/fedora/fedora-bootc:${FEDORA_MAJOR_VERSION}


### PR DESCRIPTION
## Summary
- add a preliminary `ctx` stage that copies the build_files directory
- keep final `COPY --from=ctx` instruction

## Testing
- `docker build -t hypr-blue:test .` *(fails: command not found)*
- `podman build -t hypr-blue:test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c953184748324af55b05a2e557dff