### PR TITLE
Fix Nix font package path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,7 +52,7 @@ RUN . /etc/profile.d/nix.sh && \
     nixpkgs.jq \
     nixpkgs.libnotify \
     nixpkgs.bc \
-    nixpkgs.nerdfonts.JetBrainsMono \
+    nixpkgs.nerd-fonts.jetbrains-mono \
     nixpkgs.font-awesome \
     nixpkgs.material-design-icons
 


### PR DESCRIPTION
## Summary
- fix the nerdfonts package path in Containerfile

## Testing
- `just check` *(fails: `just` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873c306ab3c8324899a933134cdde3c